### PR TITLE
Adds CNAME file for wingit.games

### DIFF
--- a/server_backup/CNAME
+++ b/server_backup/CNAME
@@ -1,0 +1,1 @@
+wingit.games


### PR DESCRIPTION
Add a CNAME file to wingit.games.

Github's documentation on setting up a domain are [here](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain). The DNS records are set up already so we just need to add the CNAME file.